### PR TITLE
fix corpus prep to cut warnings from sox and ignore (but log) errors

### DIFF
--- a/asrtoolkit/__init__.py
+++ b/asrtoolkit/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from pkg_resources import get_distribution
+
 from asrtoolkit.clean_formatting import clean_up
 from asrtoolkit.convert_transcript import convert
 from asrtoolkit.data_structures.audio_file import audio_file, combine_audio
@@ -12,6 +14,5 @@ from asrtoolkit.file_utils.name_cleaners import (
     strip_extension,
 )
 from asrtoolkit.wer import cer, wer
-from pkg_resources import get_distribution
 
 __version__ = get_distribution("asrtoolkit").version

--- a/asrtoolkit/clean_formatting.py
+++ b/asrtoolkit/clean_formatting.py
@@ -12,6 +12,7 @@ import string
 from collections import OrderedDict
 
 import regex as re
+
 from asrtoolkit.deformatting_utils import (
     digits_to_string,
     dollars_to_string,

--- a/asrtoolkit/data_handlers/html.py
+++ b/asrtoolkit/data_handlers/html.py
@@ -6,10 +6,11 @@ Note that the structure may change without notice and break backwards compatibil
 This expects a segment from class derived in convert_text
 """
 
+from bs4 import BeautifulSoup
+
 # do not delete - needed in time_aligned_text
 from asrtoolkit.data_handlers.data_handlers_common import separator
 from asrtoolkit.data_structures.segment import segment
-from bs4 import BeautifulSoup
 
 
 def table_header(text, width):

--- a/asrtoolkit/data_handlers/srt.py
+++ b/asrtoolkit/data_handlers/srt.py
@@ -5,11 +5,12 @@ Module for reading/writing SRT files
 This expects a segment from class derived in convert_text
 """
 
+from webvtt import WebVTT
+
 # do not delete - needed in time_aligned_text
 from asrtoolkit.data_handlers.data_handlers_common import footer, header, separator
 from asrtoolkit.data_handlers.webvtt_common import read_caption
 from asrtoolkit.data_structures.segment import seconds_to_timestamp
-from webvtt import WebVTT
 
 
 def format_segment(seg):

--- a/asrtoolkit/data_handlers/stm.py
+++ b/asrtoolkit/data_handlers/stm.py
@@ -8,6 +8,7 @@ This expects a segment from class derived in convert_text
 """
 
 from asrtoolkit.clean_formatting import clean_up
+
 # leave in place for other imports
 from asrtoolkit.data_handlers.data_handlers_common import footer, header, separator
 from asrtoolkit.data_structures.segment import segment

--- a/asrtoolkit/data_handlers/vtt.py
+++ b/asrtoolkit/data_handlers/vtt.py
@@ -5,11 +5,12 @@ Module for reading/writing WEBVTT files
 This expects a segment from class derived in convert_text
 """
 
+from webvtt import WebVTT
+
 # do not delete - needed for time_aligned_text
 from asrtoolkit.data_handlers.data_handlers_common import footer, separator
 from asrtoolkit.data_handlers.webvtt_common import read_caption
 from asrtoolkit.data_structures.segment import seconds_to_timestamp
-from webvtt import WebVTT
 
 
 def header():

--- a/asrtoolkit/data_structures/audio_file.py
+++ b/asrtoolkit/data_structures/audio_file.py
@@ -35,10 +35,10 @@ def cut_utterance(source_audio_file,
     subprocess.call(
         "sox -V1 {} -r {} -b 16 -c 1 {} trim {} ={}".format(
             source_audio_file,
-            str(sample_rate),
+            sample_rate,
             target_audio_file,
-            str(start_time),
-            str(end_time),
+            start_time,
+            end_time,
         ),
         shell=True,
     )

--- a/asrtoolkit/data_structures/audio_file.py
+++ b/asrtoolkit/data_structures/audio_file.py
@@ -4,6 +4,7 @@ Module for holding information about an audio file and doing basic conversions
 """
 
 import hashlib
+import logging
 import os
 import subprocess
 
@@ -12,6 +13,8 @@ from asrtoolkit.file_utils.name_cleaners import (
     sanitize_hyphens,
     strip_extension,
 )
+
+LOGGER = logging.getLogger()
 
 
 def cut_utterance(source_audio_file,
@@ -26,19 +29,17 @@ def cut_utterance(source_audio_file,
     end_time: float or str
     sample_rate: int, default 16000; audio sample rate in Hz
 
-    uses sox segment source_audio_file to create target_audio_file that contains audio from start_time to end_time
+    uses sox to segment source_audio_file to create target_audio_file that contains audio from start_time to end_time
         with audio sample rate set to sample_rate
     """
     subprocess.call(
-        [
-            "sox {} -r {} -b 16 -c 1 {} trim {} ={}".format(
-                source_audio_file,
-                str(sample_rate),
-                target_audio_file,
-                str(start_time),
-                str(end_time),
-            )
-        ],
+        "sox -V1 {} -r {} -b 16 -c 1 {} trim {} ={}".format(
+            source_audio_file,
+            str(sample_rate),
+            target_audio_file,
+            str(start_time),
+            str(end_time),
+        ),
         shell=True,
     )
 
@@ -54,20 +55,21 @@ def degrade_audio(source_audio_file, target_audio_file=None):
     # degrade to 8k
     tmp1 = ".".join(source_audio_file.split(".")[:-1]) + "_tmp1.wav"
     subprocess.call(
-        ["sox {} -r 8000 -e a-law {}".format(source_audio_file, tmp1)],
-        shell=True)
+        "sox -V1 {} -r 8000 -e a-law {}".format(source_audio_file, tmp1),
+        shell=True,
+    )
 
     # convert to u-law
     tmp2 = ".".join(source_audio_file.split(".")[:-1]) + "_tmp2.wav"
-    subprocess.call(["sox {} --rate 8000 -e u-law {}".format(tmp1, tmp2)],
-                    shell=True)
+    subprocess.call(
+        "sox -V1 {} --rate 8000 -e u-law {}".format(tmp1, tmp2),
+        shell=True,
+    )
 
     # upgrade to 16k a-law signed
     subprocess.call(
-        [
-            "sox {} --rate 16000 -e signed  -b 16 --channel 1 {}".format(
-                tmp2, target_audio_file)
-        ],
+        "sox -V1 {} --rate 16000 -e signed  -b 16 --channel 1 {}".format(
+            tmp2, target_audio_file),
         shell=True,
     )
     os.remove(tmp1)
@@ -75,15 +77,15 @@ def degrade_audio(source_audio_file, target_audio_file=None):
 
 
 def combine_audio(audio_files, output_file, gain=False):
-    # Combine audio files with possible remormalization to 0dB
+    """
+    Combine audio files with possible renormalization to 0dB
+    """
     gain_str = ""
     if gain:
         gain_str = "gain -n 0"
     subprocess.call(
-        [
-            "sox -m {} {} {}".format(" ".join(audio_files), output_file,
-                                     gain_str)
-        ],
+        "sox -V1 -m {} {} {}".format(" ".join(audio_files), output_file,
+                                     gain_str),
         shell=True,
     )
 
@@ -115,22 +117,24 @@ class audio_file(object):
     def prepare_for_training(self, file_name, sample_rate=16000):
         """
         Converts to single channel (from channel 1) audio file in SPH file format
+        Returns audio_file object on success, else None
         """
         if file_name.split(".")[-1] != "sph":
-            print("Forcing training data to use SPH file format")
+            LOGGER.warning(
+                "Forcing training data to use SPH file format for %s",
+                file_name)
             file_name = strip_extension(file_name) + ".sph"
 
         file_name = sanitize_hyphens(file_name)
-        subprocess.check_output(
-            [
-                "sox {} {} rate {} remix -".format(self.location, file_name,
-                                                   sample_rate)
-            ],
-            shell=True,
-        )
 
-        # return new object
-        return audio_file(file_name)
+        # return None if error code given, otherwise return audio_file object
+        output_file = (audio_file(file_name) if not subprocess.call(
+            "sox -V1 {} {} rate {} remix -".format(self.location, file_name,
+                                                   sample_rate),
+            shell=True,
+        ) else None)
+
+        return output_file
 
     def split(self, transcript, target_dir):
         """

--- a/asrtoolkit/data_structures/corpus.py
+++ b/asrtoolkit/data_structures/corpus.py
@@ -8,10 +8,11 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 
+from tqdm import tqdm
+
 from asrtoolkit.data_structures.audio_file import audio_file
 from asrtoolkit.data_structures.time_aligned_text import time_aligned_text
 from asrtoolkit.file_utils.name_cleaners import basename, strip_extension
-from tqdm import tqdm
 
 
 def get_files(data_dir, extension):
@@ -56,6 +57,29 @@ class exemplar(object):
                  and os.path.getsize(self.transcript_file.location))
 
         return valid
+
+    def prepare_for_training(self, target, sample_rate=16000, nested=False):
+        """
+        Prepare one exemplar for training
+        Returning a new exemplar object with updated file locations
+        and a resampled audio_file
+        """
+
+        af = self.audio_file.prepare_for_training(
+            target + ("/sph/" if nested else "/") +
+            basename(self.audio_file.location),
+            sample_rate=sample_rate,
+        )
+
+        tf = (
+            self.transcript_file.write(target + ("/stm/" if nested else "/") +
+                                       basename(self.transcript_file.location))
+            if self.audio_file is not None else None)
+
+        return (exemplar({
+            "audio_file": af,
+            "transcript_file": tf
+        }) if af is not None and tf is not None else None)
 
     def hash(self):
         """
@@ -161,31 +185,20 @@ class corpus(object):
         futures = [
             executor.submit(
                 partial(
-                    _.audio_file.prepare_for_training,
-                    file_name=target + ("/sph/" if nested else "/") +
-                    basename(_.audio_file.location),
+                    _.prepare_for_training,
+                    target=target,
                     sample_rate=sample_rate,
+                    nested=nested,
                 )) for _ in self.exemplars
         ]
 
         # trigger conversion and gather results
-        audio_files = [future.result() for future in tqdm(futures)]
-
-        transcript_files = [
-            _.transcript_file.write(target + ("/stm/" if nested else "/") +
-                                    basename(_.transcript_file.location))
-            for _ in self.exemplars
-        ]
+        new_exemplars = [future.result() for future in tqdm(futures)]
 
         new_corpus = corpus({
             "location":
             target,
-            "exemplars": [
-                exemplar({
-                    "audio_file": af,
-                    "transcript_file": tf
-                }) for af, tf in zip(audio_files, transcript_files)
-            ],
+            "exemplars": [eg for eg in new_exemplars if eg is not None],
         })
         new_corpus.validate()
         return new_corpus.log()

--- a/asrtoolkit/data_structures/corpus.py
+++ b/asrtoolkit/data_structures/corpus.py
@@ -65,14 +65,14 @@ class exemplar(object):
         and a resampled audio_file
         """
         if nested:
-            af_target_file = os.sep.join(target, "sph",
-                                         basename(self.audio_file.location))
-            tf_target_file = os.sep.join(
+            af_target_file = os.path.join(target, "sph",
+                                          basename(self.audio_file.location))
+            tf_target_file = os.path.join(
                 target, "stm", basename(self.transcript_file.location))
         else:
-            af_target_file = os.sep.join(target,
-                                         basename(self.audio_file.location))
-            tf_target_file = os.sep.join(
+            af_target_file = os.path.join(target,
+                                          basename(self.audio_file.location))
+            tf_target_file = os.path.join(
                 target, basename(self.transcript_file.location))
 
         af = self.audio_file.prepare_for_training(

--- a/asrtoolkit/data_structures/corpus.py
+++ b/asrtoolkit/data_structures/corpus.py
@@ -64,22 +64,28 @@ class exemplar(object):
         Returning a new exemplar object with updated file locations
         and a resampled audio_file
         """
+        if nested:
+            af_target_file = os.sep.join(target, "sph",
+                                         basename(self.audio_file.location))
+            tf_target_file = os.sep.join(
+                target, "stm", basename(self.transcript_file.location))
+        else:
+            af_target_file = os.sep.join(target,
+                                         basename(self.audio_file.location))
+            tf_target_file = os.sep.join(
+                target, basename(self.transcript_file.location))
 
         af = self.audio_file.prepare_for_training(
-            target + ("/sph/" if nested else "/") +
-            basename(self.audio_file.location),
+            af_target_file,
             sample_rate=sample_rate,
         )
 
-        tf = (
-            self.transcript_file.write(target + ("/stm/" if nested else "/") +
-                                       basename(self.transcript_file.location))
-            if self.audio_file is not None else None)
+        tf = self.transcript_file.write(tf_target_file)
 
-        return (exemplar({
+        return exemplar({
             "audio_file": af,
             "transcript_file": tf
-        }) if af is not None and tf is not None else None)
+        }) if all(af, tf) else None
 
     def hash(self):
         """

--- a/asrtoolkit/extract_excel_spreadsheets.py
+++ b/asrtoolkit/extract_excel_spreadsheets.py
@@ -11,6 +11,7 @@ import os
 from glob import glob
 
 import pandas as pd
+
 from asrtoolkit.clean_formatting import clean_up
 from asrtoolkit.file_utils.name_cleaners import basename, sanitize, strip_extension
 

--- a/asrtoolkit/file_utils/name_cleaners.py
+++ b/asrtoolkit/file_utils/name_cleaners.py
@@ -43,9 +43,8 @@ def sanitize(file_name, chars_to_replace="- ", silent=True):
                 format(c) +
                 "check to make sure your audio files and transcript files match"
             )
-        return os.path.join(
-            *file_name.split(os.sep)[:-1] +
-            [basename(file_name).replace(c, "_")])
+        return os.path.join(os.path.dirname(file_name),
+                            basename(file_name).replace(c, "_"))
 
     for c in chars_to_replace:
         file_name = replace_char(c, file_name)

--- a/asrtoolkit/file_utils/name_cleaners.py
+++ b/asrtoolkit/file_utils/name_cleaners.py
@@ -25,7 +25,7 @@ def basename(file_name):
 def strip_extension(file_name):
     """
     Returns file without extension
-  """
+    """
     return ".".join(file_name.split(".")[:-1]) if file_name else ""
 
 
@@ -44,7 +44,7 @@ def sanitize(file_name, chars_to_replace="- ", silent=True):
                 "check to make sure your audio files and transcript files match"
             )
         return os.path.join(
-            file_name.split(os.sep)[:-1] +
+            *file_name.split(os.sep)[:-1] +
             [basename(file_name).replace(c, "_")])
 
     for c in chars_to_replace:

--- a/asrtoolkit/file_utils/name_cleaners.py
+++ b/asrtoolkit/file_utils/name_cleaners.py
@@ -43,7 +43,7 @@ def sanitize(file_name, chars_to_replace="- ", silent=True):
                 format(c) +
                 "check to make sure your audio files and transcript files match"
             )
-        return os.sep.join(
+        return os.path.join(
             file_name.split(os.sep)[:-1] +
             [basename(file_name).replace(c, "_")])
 

--- a/asrtoolkit/prepare_audio_corpora.py
+++ b/asrtoolkit/prepare_audio_corpora.py
@@ -6,7 +6,8 @@ If present, train, test, dev sets will be used from the individual corpora
 """
 import argparse
 import json
-
+import logging
+LOGGER = logging.getLogger()
 from asrtoolkit.data_structures.corpus import corpus
 from asrtoolkit.file_utils.common_file_operations import make_list_of_dirs
 
@@ -14,7 +15,9 @@ data_dirs = ["test", "train", "dev"]
 
 
 def auto_split_corpora(corpora, min_size=50):
-    """ given input corpora dict of corpora, auto split if it doesn't satisfy all_ready constraint """
+    """
+    Given input corpora dict of corpora, auto split if it isn't already split
+    """
     all_ready = all(
         corpora[data_dir].validate() if data_dir in corpora else False
         for data_dir in data_dirs)
@@ -23,7 +26,7 @@ def auto_split_corpora(corpora, min_size=50):
     if "unsorted" in corpora:
         corpora["train"] += corpora["unsorted"]
     if not all_ready:
-        print(
+        LOGGER.warning(
             "Not all training corpora were prepared. Automatically shuffling into training, testing, development sets"
         )
 

--- a/asrtoolkit/wer.py
+++ b/asrtoolkit/wer.py
@@ -7,6 +7,7 @@ import argparse
 import re
 
 import editdistance
+
 from asrtoolkit.clean_formatting import clean_up
 from asrtoolkit.data_structures.time_aligned_text import time_aligned_text
 from asrtoolkit.file_utils.script_input_validation import assign_if_valid

--- a/tests/test_split_audio_file.py
+++ b/tests/test_split_audio_file.py
@@ -8,7 +8,9 @@ from asrtoolkit.split_audio_file import split_audio_file
 
 
 def test_split_audio_file():
-    " test audio file splitter "
+    """
+    Test audio file splitter
+    """
     split_audio_file("tests/small-test-file.mp3", "tests/small-test-file.stm",
                      "tests/split")
     assert set(os.listdir("tests/split")) == {


### PR DESCRIPTION
Errors were blocking downstream usage, and we want to tolerate issues like empty files but log them