### PR TITLE
lint as part of ci and change arg parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,12 @@ install:
   - python3 setup.py build
   - python3 setup.py install
   - python3 -m pip install .[dev]
-  - pip install -r requirements.txt
+  - python3 -m pip install -r requirements.txt
+  - python3 -m pip install flake8
 # command to run tests
 script:
+  # run test suite
   - python -m pytest -v --doctest-modules
+  # check for undefined variables (F821 is an excellent error for a linter to catch)
+  # add errors to ignore here as desired
+  - python3 -m flake8 --ignore=E501,W504,W503,W291,F401,E741,E302,E126,E402,E251 .

--- a/asrtoolkit/align_json.py
+++ b/asrtoolkit/align_json.py
@@ -21,6 +21,10 @@ def align_json(ref_txt, json_file, filename=None):
     Using a reference txt file and a hypothesis gk json 
         file, this time-aligns the reference txt file 
         and outputs an STM file
+    Input
+      ref_txt, str - reference text file containing ground truth
+      json_file, str - hypothesis gk JSON file
+      filename, str - output STM filename
     """
 
     ref_tokens = preprocess_txt.parse_transcript(ref_txt)

--- a/asrtoolkit/align_json.py
+++ b/asrtoolkit/align_json.py
@@ -3,18 +3,24 @@
 Forced alignment tools CLI
 """
 
-import argparse
+from fire import Fire
 
 from asrtoolkit.alignment import preprocess_gk_json, preprocess_txt
 from asrtoolkit.alignment.align import align
 from asrtoolkit.data_structures.time_aligned_text import time_aligned_text
-from asrtoolkit.file_utils.name_cleaners import basename, sanitize, strip_extension
+from asrtoolkit.file_utils.name_cleaners import (
+    basename,
+    sanitize,
+    strip_extension,
+)
 
 
 def align_json(ref_txt, json_file, filename=None):
     """
-    Wraps alignment tools to allow for forced alignment of a gk json hypothesis against a reference text file
-    Produces a time-aligned stm file named filename using the correct transcript where alignments were detected
+    CLI for forced alignment tools
+    Using a reference txt file and a hypothesis gk json 
+        file, this time-aligns the reference txt file 
+        and outputs an STM file
     """
 
     ref_tokens = preprocess_txt.parse_transcript(ref_txt)
@@ -34,29 +40,9 @@ def align_json(ref_txt, json_file, filename=None):
     output.write(filename)
 
 
-def main():
-    """
-    CLI for forced alignment tools
-    """
-    parser = argparse.ArgumentParser(
-        description="align a gk json file against a reference text file")
-    parser.add_argument("input_json",
-                        metavar="input_json",
-                        type=str,
-                        help="input gk json file")
-    parser.add_argument("ref",
-                        metavar="ref",
-                        type=str,
-                        help="reference text file")
-    parser.add_argument("output_filename",
-                        metavar="output_filename",
-                        type=str,
-                        default=None,
-                        help="output_filename")
-
-    args = parser.parse_args()
-    align_json(args.ref, args.input_json, args.output_filename)
+def cli():
+    Fire(align_json)
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/asrtoolkit/alignment/aligned_doc.py
+++ b/asrtoolkit/alignment/aligned_doc.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
-from collections import defaultdict, deque
-from toolz import merge, merge_sorted
-import spacy
 import logging
+from collections import defaultdict, deque
+
+import spacy
+from toolz import merge, merge_sorted
+
 from asrtoolkit.alignment.align_utils import find_matched_intervals, is_sorted
 
 LOGGER = logging.getLogger(__name__)
@@ -87,8 +89,8 @@ class AlignedDoc:
             match for match in matched_segments
             if match not in self.matched_intervals
         ]
-        LOGGER.debug("Number of non-unique matched_segments: {}".format(
-            len(matched_segments) - len(unique_new_spans)))
+        LOGGER.debug("Number of non-unique matched_segments: %s",
+                     len(matched_segments) - len(unique_new_spans))
         return unique_new_spans
 
     def find_unmatched_segments(self, interval, matched_segments):
@@ -141,7 +143,7 @@ class AlignedDoc:
     def find_alignments(self, extract_id):
         all_matched_segments, all_unmatched_segments = [], []
 
-        for interval_id, interval in enumerate(self.unmatched_intervals):
+        for interval in self.unmatched_intervals:
             matched_segments = find_matched_intervals(
                 interval=interval, extractor=self.extractors[extract_id])
 
@@ -191,7 +193,7 @@ class AlignedDoc:
             m2_tokens = self.get_token_idxs(ref_match)
             for hyp_tok, ref_tok in zip(m1_tokens, m2_tokens):
                 matched = (hyp_tok, ref_tok)
-                if not matched in token_matches and is_sorted(token_matches +
+                if matched not in token_matches and is_sorted(token_matches +
                                                               [matched]):
                     token_matches.append(matched)
         return token_matches

--- a/asrtoolkit/clean_formatting.py
+++ b/asrtoolkit/clean_formatting.py
@@ -4,14 +4,12 @@
 Text line cleaning functions. For WER calculations, final text should be utf letter chars and \'
 """
 
-from __future__ import print_function
-
-import argparse
 import logging
 import string
 from collections import OrderedDict
 
 import regex as re
+from fire import Fire
 
 from asrtoolkit.deformatting_utils import (
     digits_to_string,
@@ -206,49 +204,36 @@ def clean_up(input_line):
     return input_line.strip()
 
 
-def clean_text_file(input_text_file):
+def clean_text_file(*input_text_files):
     """
-    Clean a text file
+    Cleans input *.txt files and outputs *_cleaned.txt
     """
-
-    with open(input_text_file, "r", encoding="utf-8") as f:
-        lines = f.read().splitlines()
-
-    cleaned = []
-    for line in lines:
-        cleaned.append(clean_up(line))
-
-    with open(input_text_file.replace(".txt", "") + "_cleaned.txt",
-              "w",
-              encoding="utf-8") as f:
-        f.write(" ".join(cleaned))
-
-    print("File output: " + input_text_file.replace(".txt", "") +
-          "_cleaned.txt")
-
-
-def main():
-    """
-    Either run tests or clean formatting for files, depending on # of arguments
-    """
-
-    parser = argparse.ArgumentParser(
-        description="cleans input *.txt files and outputs *_cleaned.txt")
-    parser.add_argument("files",
-                        type=str,
-                        nargs="+",
-                        help="list of input files")
-
-    args = parser.parse_args()
-    for file_name in args.files:
-        if not valid_input_file(file_name, valid_extensions=["txt"]):
+    for input_text_file in input_text_files:
+        if not valid_input_file(input_text_file, valid_extensions=["txt"]):
             LOGGER.error(
                 "File %s does not end in .txt - please only use this for cleaning txt files",
-                file_name,
+                input_text_file,
             )
             continue
-        clean_text_file(file_name)
+
+        with open(input_text_file, "r", encoding="utf-8") as f:
+            lines = f.read().splitlines()
+
+        cleaned = []
+        for line in lines:
+            cleaned.append(clean_up(line))
+
+        with open(input_text_file.replace(".txt", "") + "_cleaned.txt",
+                  "w",
+                  encoding="utf-8") as f:
+            f.write(" ".join(cleaned))
+
+        LOGGER.info("File output: " + input_text_file.replace(".txt", "") +
+                    "_cleaned.txt")
+
+def cli():
+    Fire(clean_text_file)
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/asrtoolkit/convert_transcript.py
+++ b/asrtoolkit/convert_transcript.py
@@ -3,9 +3,10 @@
 Python class for converting file formats used in Automatic Speech Recognition
 """
 
-import argparse
 import logging
 import sys
+
+from fire import Fire
 
 from asrtoolkit.file_utils.script_input_validation import assign_if_valid
 
@@ -14,32 +15,22 @@ LOGGER = logging.getLogger(__name__)
 
 def check_input_file_validity(input_file):
     if input_file is None:
-        LOGGER.error("Invalid input file {}".format(input_file))
+        LOGGER.error("Invalid input file %s", input_file)
         sys.exit(1)
 
 
 def convert(input_file, output_file):
+    """
+    Convert between text file formats
+    """
+    check_input_file_validity(input_file)
     input_file = assign_if_valid(input_file)
     input_file.write(output_file)
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="convert between text file formats")
-    parser.add_argument("input_file",
-                        metavar="input_file",
-                        type=str,
-                        help="input file")
-    parser.add_argument("output_file",
-                        metavar="output_file",
-                        type=str,
-                        help="output file")
-    args = parser.parse_args()
-
-    check_input_file_validity(args.input_file)
-
-    convert(args.input_file, args.output_file)
+def cli():
+    Fire(convert)
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/asrtoolkit/convert_transcript.py
+++ b/asrtoolkit/convert_transcript.py
@@ -21,7 +21,7 @@ def check_input_file_validity(input_file):
 
 def convert(input_file, output_file):
     """
-    Convert between text file formats
+    Convert between text file formats (supported formats are stm, json, srt, vtt, and html)
     """
     check_input_file_validity(input_file)
     input_file = assign_if_valid(input_file)

--- a/asrtoolkit/data_structures/audio_file.py
+++ b/asrtoolkit/data_structures/audio_file.py
@@ -8,10 +8,12 @@ import logging
 import os
 import subprocess
 
-from asrtoolkit.file_utils.name_cleaners import (generate_segmented_file_name,
-                                                 sanitize_hyphens,
-                                                 strip_extension)
-
+from asrtoolkit.file_utils.name_cleaners import (
+    generate_segmented_file_name,
+    sanitize_hyphens,
+    strip_extension,
+)
+from asrtoolkit.file_utils.script_input_validation import valid_input_file
 LOGGER = logging.getLogger()
 
 
@@ -48,6 +50,8 @@ def degrade_audio(source_audio_file, target_audio_file=None):
     Degrades audio to typical G711 level.
     Useful if models need to target this audio quality.
     """
+
+    valid_input_file(source_audio_file, ["mp3", "sph", "wav", "au", "raw"])
 
     target_audio_file = (source_audio_file
                          if target_audio_file is None else target_audio_file)

--- a/asrtoolkit/degrade_audio_file.py
+++ b/asrtoolkit/degrade_audio_file.py
@@ -4,7 +4,8 @@ Script for degrading audio files to G711 audio quality
 """
 
 import logging
-import sys
+
+from fire import Fire
 
 from asrtoolkit.data_structures.audio_file import degrade_audio
 from asrtoolkit.file_utils.script_input_validation import valid_input_file
@@ -12,16 +13,20 @@ from asrtoolkit.file_utils.script_input_validation import valid_input_file
 LOGGER = logging.getLogger(__name__)
 
 
-def main():
+def degrade_all_files(*audio_files):
     """
     Degrade all audio files given as arguments (in place by default)
     """
-    for file_name in sys.argv[1:]:
+    for file_name in audio_files:
         if valid_input_file(file_name, ["mp3", "sph", "wav", "au", "raw"]):
             degrade_audio(file_name)
         else:
             LOGGER.error("Invalid input file %s", file_name)
 
 
+def cli():
+    Fire(degrade_all_files)
+
+
 if __name__ == "__main__":
-    main()
+    cli()

--- a/asrtoolkit/split_audio_file.py
+++ b/asrtoolkit/split_audio_file.py
@@ -3,9 +3,10 @@
 Script for splitting audio files using a transcript with start/stop times
 """
 
-import argparse
 import logging
 import sys
+
+from fire import Fire
 
 from asrtoolkit.data_structures.audio_file import audio_file
 from asrtoolkit.data_structures.time_aligned_text import time_aligned_text
@@ -14,7 +15,9 @@ from asrtoolkit.file_utils.script_input_validation import valid_input_file
 LOGGER = logging.getLogger(__name__)
 
 
-def split_audio_file(source_audio_file, source_transcript, target_directory):
+def split_audio_file(source_audio_file,
+                     source_transcript,
+                     target_directory="split"):
     """
     Split source audio file into segments denoted by transcript file
     into target_directory
@@ -30,42 +33,20 @@ def validate_transcript(transcript):
     Exit if invalid transcript
     """
     if not valid_input_file(transcript):
-        LOGGER.error("Invalid transcript file {}".format(transcript))
+        LOGGER.error("Invalid transcript file %s", transcript)
         sys.exit(1)
 
 
 def validate_audio_file(source_audio_file):
     if not valid_input_file(source_audio_file,
                             ["mp3", "sph", "wav", "au", "raw"]):
-        LOGGER.error("Invalid audio file {}".format(source_audio_file))
+        LOGGER.error("Invalid audio file %s", source_audio_file)
         sys.exit(1)
 
 
-def main():
-    """
-    Split audio file using transcript file
-    """
-    parser = argparse.ArgumentParser(
-        description=
-        "Split an audio file using valid segments from a transcript file. For this utility, transcript files must contain start/stop times."
-    )
-    parser.add_argument("--target-dir",
-                        default="split",
-                        required=False,
-                        help="Path to target directory")
-    parser.add_argument("audio_file",
-                        metavar="audio_file",
-                        type=str,
-                        help="input audio file")
-    parser.add_argument("transcript",
-                        metavar="transcript",
-                        type=str,
-                        help="transcript")
-
-    args = parser.parse_args()
-
-    split_audio_file(args.audio_file, args.transcript, args.target_dir)
+def cli():
+    Fire(split_audio_file)
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/asrtoolkit/validate_stm.py
+++ b/asrtoolkit/validate_stm.py
@@ -3,24 +3,24 @@
 Python class for validating STM files used in Automatic Speech Recognition
 """
 
-import argparse
+from fire import Fire
 
 from asrtoolkit.convert_transcript import convert
 
 
-def validate():
-    parser = argparse.ArgumentParser(
-        description="convert between text file formats")
-    parser.add_argument("input_file",
-                        metavar="input_file",
-                        type=str,
-                        help="input file")
-    args = parser.parse_args()
+def validate(input_file):
+    """
+    Overwrites an STM file, leaving only valid input lines
+    """
 
     # after reading in, only valid lines will remain
     # so write it back in place
-    convert(args.input_file, args.input_file)
+    convert(input_file, input_file)
+
+
+def cli():
+    Fire(validate)
 
 
 if __name__ == "__main__":
-    validate()
+    cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4
 editdistance
+fire
 num2words
 pytest
 regex

--- a/setup.py
+++ b/setup.py
@@ -69,15 +69,15 @@ setup(
     keywords="asr speech recognition greenkey gk word error rate",
     entry_points={
         "console_scripts": [
-            "align_json=asrtoolkit.align_json:main",
-            "clean_formatting=asrtoolkit.clean_formatting:main",
+            "align_json=asrtoolkit.align_json:cli",
+            "clean_formatting=asrtoolkit.clean_formatting:cli",
             "combine_audio_files=asrtoolkit.combine_audio_files:main",
-            "convert_transcript = asrtoolkit.convert_transcript:main",
-            "degrade_audio_file=asrtoolkit.degrade_audio_file:main",
+            "convert_transcript = asrtoolkit.convert_transcript:cli",
+            "degrade_audio_file=asrtoolkit.degrade_audio_file:cli",
             "extract_excel_spreadsheets=asrtoolkit.extract_excel_spreadsheets:main",
-            "prepare_audio_corpora=asrtoolkit.prepare_audio_corpora:main",
-            "split_audio_file=asrtoolkit.split_audio_file:main",
-            "wer=asrtoolkit.wer:main",
+            "prepare_audio_corpora=asrtoolkit.prepare_audio_corpora:cli",
+            "split_audio_file=asrtoolkit.split_audio_file:cli",
+            "wer=asrtoolkit.wer:cli",
         ]
     },
     license="Apache v2",

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -4,12 +4,15 @@ Test to ensure that alignment can work
 """
 import hashlib
 
-from asrtoolkit.align_json import align_json
+from asrtoolkit import align_json
 
 
 def test_simple_alignment():
-    align_json("samples/BillGatesTEDTalk.txt", "samples/BillGatesTEDTalk.json",
-               "tests/BillGatesTEDTalk_aligned.stm")
+    align_json(
+        "samples/BillGatesTEDTalk.txt",
+        "samples/BillGatesTEDTalk.json",
+        "tests/BillGatesTEDTalk_aligned.stm",
+    )
     new_sha = hashlib.sha1(
         open("tests/BillGatesTEDTalk_aligned.stm", "r",
              encoding="utf8").read().encode()).hexdigest()


### PR DESCRIPTION
1. Add flake8 to travis tests so we can catch undefined variable errors
2. Moves most CLIs from argparse to fire

Reasoning for 2 above:
- The more logic there is in the cli wrapper, the less test coverage we have of that logic. If we can push all the logic down into the function therein invoked, then we get coverage of that logic. The CLIs are all a lot simpler as Fire(function_that_does_logic). 

Two scripts were not migrated away from argparse- combine_audio_files and the extract_excel_spreadsheets. The former has no testing, so I'm not making changes until that's built (see #97). The latter is planned to be reworked in #81 