### PR TITLE
Add script to create data split for corpus with specific number of words

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Matthew Goldey <mgoldey@greenkeytech.com>" \
 
 # APT INSTALLS
 RUN apt update && \
-    apt install -y python3-dev libsox-fmt-mp3 wget curl build-essential && \
+    apt install -y python3-dev libsox-fmt-mp3 wget curl build-essential sox && \
     apt-get clean autoclean && \
     apt-get autoremove -y && \
     rm -rf /usr/share/doc /var/lib/apt/lists/* && \

--- a/asrtoolkit/data_structures/corpus.py
+++ b/asrtoolkit/data_structures/corpus.py
@@ -171,17 +171,25 @@ class corpus(object):
         self.exemplars = [dict_of_examples[_] for _ in set(dict_of_examples)]
         return sum(_.validate() for _ in self.exemplars)
 
+    def count_exemplar_words(self):
+        """
+        Count the number of words in valid corpus exemplars
+        adds attribute n_words to exemplars
+        """
+        valid_exemplars = [_ for _ in self.exemplars if _.validate()]
+
+        total_words = 0
+        for eg in valid_exemplars:
+            eg.n_words = eg.count_words()
+            total_words += eg.n_words
+        return valid_exemplars, total_words
+
     def split(self, split_words):
         """
         Select exemplars to create data split with specified number of words
         Returns the new splits as separate corpora
         """
-        valid_exemplars = [_ for _ in self.exemplars if _.validate()]
-  
-        total_words = 0
-        for eg in valid_exemplars:
-            eg.n_words = eg.count_words()
-            total_words += eg.n_words
+        valid_exemplars, total_words = self.count_exemplar_words()
 
         # Raise error if we inputs are invalid to avoid infinite loop
         if split_words < 0 or split_words > total_words:
@@ -189,7 +197,7 @@ class corpus(object):
 
         exemplars_in_split = []
         while split_words >= 0:
-            exemplars_in_split += [valid_exemplars.pop(random.randrange(len(self.exemplars)))]
+            exemplars_in_split += [valid_exemplars.pop(random.randrange(len(valid_exemplars)))]
             split_words -= exemplars_in_split[-1].n_words
 
         new_corpus = corpus({
@@ -201,7 +209,6 @@ class corpus(object):
         remaining_corpus.location = self.location
 
         return remaining_corpus, new_corpus
-
 
     def log(self):
         """

--- a/asrtoolkit/data_structures/corpus.py
+++ b/asrtoolkit/data_structures/corpus.py
@@ -184,9 +184,9 @@ class corpus(object):
             total_words += eg.n_words
         return valid_exemplars, total_words
 
-    def split(self, split_words):
+    def split(self, split_words, min_segments=10):
         """
-        Select exemplars to create data split with specified number of words
+        Select exemplars to create data split with specified number of words and minimum number of segments
         Returns the new splits as separate corpora
         """
         valid_exemplars, total_words = self.count_exemplar_words()
@@ -196,9 +196,11 @@ class corpus(object):
             raise ValueError("cannot split corpus with {} words into split with {} words".format(total_words, split_words))
 
         exemplars_in_split = []
-        while split_words >= 0:
+        word_counter, seg_counter = 0, 0
+        while word_counter <= split_words or seg_counter <= min_segments:
             exemplars_in_split += [valid_exemplars.pop(random.randrange(len(valid_exemplars)))]
-            split_words -= exemplars_in_split[-1].n_words
+            word_counter += exemplars_in_split[-1].n_words
+            seg_counter += len(exemplars_in_split[-1].transcript_file.segments)
 
         new_corpus = corpus({
             "location": self.location,

--- a/asrtoolkit/data_structures/corpus.py
+++ b/asrtoolkit/data_structures/corpus.py
@@ -5,11 +5,13 @@ Module for organizing SPH/MP3/WAV & STM files from a corpus
 
 import glob
 import os
+import random
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 
 from tqdm import tqdm
 
+from asrtoolkit.clean_formatting import clean_up
 from asrtoolkit.data_structures.audio_file import audio_file
 from asrtoolkit.data_structures.time_aligned_text import time_aligned_text
 from asrtoolkit.file_utils.name_cleaners import basename, strip_extension
@@ -58,8 +60,14 @@ class exemplar(object):
         valid = (audio_filename == transcript_filename
                  and os.path.getsize(self.audio_file.location)
                  and os.path.getsize(self.transcript_file.location))
+        # This returns an integer corresponding to the output of the last condition, not a boolean.
+        # Thats just how `and` works in python
 
-        return valid
+        return bool(valid)
+
+    def count_words(self, clean_func=clean_up):
+        """ Count words in a exemplar after cleaning it """
+        return len(clean_func(self.transcript_file.text()).split()) if self.validate() else 0
 
     def prepare_for_training(self, target, sample_rate=16000, nested=False):
         """
@@ -156,12 +164,44 @@ class corpus(object):
 
     def validate(self):
         """
-        Check to and validate each example after sorting by audio file hash
+        Check and validate each example after sorting by audio file hash
         since stm hash may change
         """
         dict_of_examples = {_.audio_file.hash(): _ for _ in self.exemplars}
         self.exemplars = [dict_of_examples[_] for _ in set(dict_of_examples)]
         return sum(_.validate() for _ in self.exemplars)
+
+    def split(self, split_words):
+        """
+        Select exemplars to create data split with specified number of words
+        Returns the new splits as separate corpora
+        """
+        valid_exemplars = [_ for _ in self.exemplars if _.validate()]
+  
+        total_words = 0
+        for eg in valid_exemplars:
+            eg.n_words = eg.count_words()
+            total_words += eg.n_words
+
+        # Raise error if we inputs are invalid to avoid infinite loop
+        if split_words < 0 or split_words > total_words:
+            raise ValueError("cannot split corpus with {} words into split with {} words".format(total_words, split_words))
+
+        exemplars_in_split = []
+        while split_words >= 0:
+            exemplars_in_split += [valid_exemplars.pop(random.randrange(len(self.exemplars)))]
+            split_words -= exemplars_in_split[-1].n_words
+
+        new_corpus = corpus({
+            "location": self.location,
+            "exemplars": exemplars_in_split,
+        })
+
+        remaining_corpus = self - new_corpus
+        remaining_corpus.location = self.location
+
+        return remaining_corpus, new_corpus
+
 
     def log(self):
         """

--- a/asrtoolkit/split_corpus.py
+++ b/asrtoolkit/split_corpus.py
@@ -16,17 +16,18 @@ from asrtoolkit.data_structures.corpus import corpus
 LOGGER = logging.getLogger(__name__)
 
 
-def log_corpus_creation(corpus, name):
+def log_corpus_creation(corp, name):
     """ had to make this function to satisfy code climate """
     LOGGER.info(
-        'Created %s split with %d words using %d files',
-        corpus.location,
-        sum(map(lambda x: x.n_words, corpus.exemplars)),
-        len(corpus.exemplars)
+        'Created %s split with %d words using %d files with %d segments',
+        corp.location,
+        sum(map(lambda x: x.n_words, corp.exemplars)),
+        len(corp.exemplars),
+        corp.calculate_number_of_segments()
     )
 
 
-def split_corpus(in_dir, split_dir, split_name='split', split_words=1000, leftover_data_split_name='orig', rand_seed=None):
+def split_corpus(in_dir, split_dir, split_name='split', split_words=1000, min_split_segs=10, leftover_data_split_name='orig', rand_seed=None):
     """
     Splits an ASR corpus directory based on number of words outputting splits in split_dir.
     At least 1000 words is recommended for dev or tests splits to make WER calculations significant ~0.1%
@@ -55,7 +56,15 @@ def split_corpus(in_dir, split_dir, split_name='split', split_words=1000, leftov
         )
         sys.exit(1)
 
-    leftover_corpus, new_corpus = c.split(split_words)
+    if min_split_segs > c.calculate_number_of_segments():
+        LOGGER.error(
+            'Not enough valid segments in corpus, %d, to make a split with %d segments. Reduce min_split_segs or get more data',
+            c.calculate_number_of_segments(),
+            min_split_segs,
+        )
+        sys.exit(1)
+
+    leftover_corpus, new_corpus = c.split(split_words, min_split_segs)
 
     new_corpus.prepare_for_training(os.path.join(split_dir, split_name))
     log_corpus_creation(new_corpus, split_name)

--- a/asrtoolkit/split_corpus.py
+++ b/asrtoolkit/split_corpus.py
@@ -49,22 +49,9 @@ def split_corpus(in_dir, split_dir, split_name='split', split_words=1000, min_sp
 
     c = corpus({"location": in_dir})
     LOGGER.debug("%d exemplars before validating them", len(c.exemplars))
-    valid_exemplars = [_ for _ in c.exemplars if _.validate()]
+    valid_exemplars, total_words = c.count_exemplars()
     c.exemplars = valid_exemplars
     LOGGER.debug("%d exemplars after validating them", len(valid_exemplars))
-
-    total_words = 0
-    for e in valid_exemplars:
-        e.n_words = e.count_words()
-        total_words += e.n_words
-
-    if split_words > total_words:
-        LOGGER.error(
-            'Not enough words in corpus, %d, to make a split with %d words. Reduce words in data split.',
-            total_words,
-            split_words,
-        )
-        sys.exit(1)
 
     if min_split_segs > c.calculate_number_of_segments():
         LOGGER.error(

--- a/asrtoolkit/split_corpus.py
+++ b/asrtoolkit/split_corpus.py
@@ -26,10 +26,6 @@ def log_corpus_creation(corpus, name):
     )
 
 
-def create_new_split(corpus, target):
-    return leftover_corpus
-
-
 def split_corpus(in_dir, split_dir, split_name='split', split_words=1000, leftover_data_split_name='orig', rand_seed=None):
     """
     Splits an ASR corpus directory based on number of words outputting splits in split_dir.
@@ -39,13 +35,14 @@ def split_corpus(in_dir, split_dir, split_name='split', split_words=1000, leftov
     Set rand_seed for reproducible splits
     """
     seed(rand_seed)
+    split_name
 
     c = corpus({"location": in_dir})
     LOGGER.debug("%d exemplars before validating them", len(c.exemplars))
     valid_exemplars = [_ for _ in c.exemplars if _.validate()]
     c.exemplars = valid_exemplars
     LOGGER.debug("%d exemplars after validating them", len(valid_exemplars))
-  
+
     total_words = 0
     for e in valid_exemplars:
         e.n_words = e.count_words()
@@ -59,7 +56,6 @@ def split_corpus(in_dir, split_dir, split_name='split', split_words=1000, leftov
         )
         sys.exit(1)
 
-    
     leftover_corpus, new_corpus = c.split(split_words)
 
     new_corpus.prepare_for_training(os.path.join(split_dir, split_name))

--- a/asrtoolkit/split_corpus.py
+++ b/asrtoolkit/split_corpus.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Create train, dev, and test splits a folder of ASR data
+"""
+
+import logging
+import os
+import sys
+from random import seed, randrange
+
+from fire import Fire
+
+from asrtoolkit.clean_formatting import clean_up
+from asrtoolkit.data_structures.corpus import corpus
+
+LOGGER = logging.getLogger(__name__)
+
+def count_words(exemplar):
+    """ Count words in a exemplar after cleaning it """
+    return len(clean_up(exemplar.transcript_file.text()).split())
+
+
+def generate_data_split(exemplars, words):
+    """ Select exemplars to create data split with specified number of words """
+    split_words = 0
+    exemplars_in_split = []
+    while split_words <= words:
+        exemplars_in_split += [exemplars.pop(randrange(len(exemplars)))]
+        split_words += exemplars_in_split[-1].n_words
+    return exemplars_in_split, exemplars
+
+
+def make_data_split(exemplars, out_dir):
+   """ Move exemplars to a dev and test directory for corpus """
+   for e in exemplars:
+       os.rename(
+           e.transcript_file.location,
+           os.path.join(out_dir, os.path.basename(e.transcript_file.location))
+       )
+       os.rename(
+           e.audio_file.location,
+           os.path.join(out_dir, os.path.basename(e.audio_file.location))
+       )
+
+
+def split_corpus(in_dir, dev_dir='dev', dev_words=1000, tst_dir='test', test_words=1000, rand_seed=None, override=False):
+    """
+    Splits an ASR corpus directory based on number of words. At least 1000 words is recommended for each split.
+    This means WER calculations are significant to about a tenth of a percent.
+    Invalid files, such as empty files, will not be included in data splits.
+    Set rand_seed for reproducible splits
+
+    If you want more than 50% of the input data in dev and tests splits set override=True
+    """
+    seed(rand_seed)
+    # Look in directory for all valid pairs of stm and audio file
+    c = corpus({"location": in_dir})
+    LOGGER.debug("%d exemplars before validating them", len(c.exemplars))
+    valid_exemplars = [_ for _ in c.exemplars if _.validate()]
+    LOGGER.debug("%d exemplars after validating them", len(valid_exemplars))
+    # Count text from all valid stm files
+  
+    total_words = 0
+    for e in valid_exemplars:
+        e.n_words = count_words(e)
+        total_words += e.n_words
+
+    if dev_words + test_words > total_words:
+        LOGGER.error(
+            'Not enough words in corpus, %d, to split into groups %d and %d. Reduce words in data splits.',
+            total_words,
+            dev_words,
+            test_words,
+        )
+        sys.exit(1)
+    elif override or dev_words + test_words > 0.5 * total_words:
+        LOGGER.error(
+            "More than 50% of corpus words, %d, are being put into dev and tests splits (%d and %d). Set override=true if you still want to split",
+            total_words,
+            dev_words,
+            test_words,
+        )
+        sys.exit(1)
+
+    # Sample files to get enough words for corpus
+    dev_exemplars, valid_exemplars = generate_data_split(valid_exemplars, dev_words)
+    test_exemplars, _ = generate_data_split(valid_exemplars, test_words)
+
+    LOGGER.info(
+        'Making dev split with %d words using %d files',
+        sum(map(lambda x: x.n_words, dev_exemplars)),
+        len(dev_exemplars)
+    )
+    make_data_split(dev_exemplars, dev_dir)
+    LOGGER.info(
+        'Making test split with %d words using %d files',
+        sum(map(lambda x: x.n_words, test_exemplars)),
+        len(test_exemplars)
+    )
+    make_data_split(test_exemplars, tst_dir)
+
+def cli():
+    Fire(split_corpus)
+
+
+if __name__ == "__main__":
+    cli()

--- a/asrtoolkit/split_corpus.py
+++ b/asrtoolkit/split_corpus.py
@@ -35,7 +35,6 @@ def split_corpus(in_dir, split_dir, split_name='split', split_words=1000, leftov
     Set rand_seed for reproducible splits
     """
     seed(rand_seed)
-    split_name
 
     c = corpus({"location": in_dir})
     LOGGER.debug("%d exemplars before validating them", len(c.exemplars))

--- a/asrtoolkit/split_corpus.py
+++ b/asrtoolkit/split_corpus.py
@@ -49,7 +49,7 @@ def split_corpus(in_dir, split_dir, split_name='split', split_words=1000, min_sp
 
     c = corpus({"location": in_dir})
     LOGGER.debug("%d exemplars before validating them", len(c.exemplars))
-    valid_exemplars, total_words = c.count_exemplars()
+    valid_exemplars, total_words = c.count_exemplar_words()
     c.exemplars = valid_exemplars
     LOGGER.debug("%d exemplars after validating them", len(valid_exemplars))
 

--- a/asrtoolkit/split_corpus.py
+++ b/asrtoolkit/split_corpus.py
@@ -27,6 +27,16 @@ def log_corpus_creation(corp, name):
     )
 
 
+def perform_split(corpus_to_split, split_dir, split_name, split_words, min_split_segs, leftover_data_split_name):
+    leftover_corpus, new_corpus = corpus_to_split.split(split_words, min_split_segs)
+
+    new_corpus.prepare_for_training(os.path.join(split_dir, split_name))
+    log_corpus_creation(new_corpus, split_name)
+
+    leftover_corpus.prepare_for_training(os.path.join(split_dir, leftover_data_split_name))
+    log_corpus_creation(leftover_corpus, leftover_data_split_name)
+
+
 def split_corpus(in_dir, split_dir, split_name='split', split_words=1000, min_split_segs=10, leftover_data_split_name='orig', rand_seed=None):
     """
     Splits an ASR corpus directory based on number of words outputting splits in split_dir.
@@ -64,13 +74,7 @@ def split_corpus(in_dir, split_dir, split_name='split', split_words=1000, min_sp
         )
         sys.exit(1)
 
-    leftover_corpus, new_corpus = c.split(split_words, min_split_segs)
-
-    new_corpus.prepare_for_training(os.path.join(split_dir, split_name))
-    log_corpus_creation(new_corpus, split_name)
-
-    leftover_corpus.prepare_for_training(os.path.join(split_dir, leftover_data_split_name))
-    log_corpus_creation(leftover_corpus, leftover_data_split_name)
+    perform_split(c, split_dir, split_name, split_words, min_split_segs, leftover_data_split_name)
 
 
 def cli():

--- a/tests/docker_test.sh
+++ b/tests/docker_test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+files_to_cleanup="corpus split-corpus split file_conversion_test.txt file_conversion_test.stm json_to_stm_test_2.stm json_to_txt_test.txt json_to_stm_test_1.stm stm_to_srt_test.srt stm_to_vtt_test.vtt stm_to_html_test.html stm_to_txt_test.txt BillGatesTEDTalk_aligned.stm __pycache__"
+
+docker run --rm -it -w /work \
+  --user $(id -u):$(id -g) --userns=host \
+  -v $PWD:/work asrtoolkit:${TAG:-latest} \
+  bash -c 'tests/run_tests.sh'
+(cd tests/ && rm -r $files_to_cleanup)

--- a/tests/docker_test.sh
+++ b/tests/docker_test.sh
@@ -4,6 +4,7 @@ files_to_cleanup="corpus split-corpus split file_conversion_test.txt file_conver
 
 docker run --rm -it -w /work \
   --user $(id -u):$(id -g) --userns=host \
+  -e LOG_LEVEL=${LOG_LEVEL:-DEBUG} \
   -v $PWD:/work asrtoolkit:${TAG:-latest} \
   bash -c 'tests/run_tests.sh'
 (cd tests/ && rm -r $files_to_cleanup)

--- a/tests/docker_test.sh
+++ b/tests/docker_test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+# Run this from the head of git repo
+
 files_to_cleanup="corpus split-corpus split file_conversion_test.txt file_conversion_test.stm json_to_stm_test_2.stm json_to_txt_test.txt json_to_stm_test_1.stm stm_to_srt_test.srt stm_to_vtt_test.vtt stm_to_html_test.html stm_to_txt_test.txt BillGatesTEDTalk_aligned.stm __pycache__"
 
 docker run --rm -it -w /work \
@@ -8,3 +10,6 @@ docker run --rm -it -w /work \
   -v $PWD:/work asrtoolkit:${TAG:-latest} \
   bash -c 'tests/run_tests.sh'
 (cd tests/ && rm -r $files_to_cleanup)
+
+# Then tests formatting as in CI
+python3 -m flake8 --ignore=E501,W504,W503,W291,F401,E741,E302,E126,E402,E251 .

--- a/tests/test_split_corpus.py
+++ b/tests/test_split_corpus.py
@@ -46,6 +46,7 @@ def test_split_corpus():
         split_dir=split_dir,
         split_name="dev",
         split_words=19,
+        min_split_segs=1,
         leftover_data_split_name="train",
         rand_seed=1337,
     )

--- a/tests/test_split_corpus.py
+++ b/tests/test_split_corpus.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+"""
+Test audio file splitter
+"""
+import os
+import shutil
+from os.path import join as pjoin
+
+from asrtoolkit.split_corpus import split_corpus
+
+
+def setup_test_corpus(trn_dir, dev_dir, tst_dir):
+    """ Setup fake corpus for testing """
+    os.makedirs(trn_dir, exist_ok=True)
+    os.makedirs(dev_dir, exist_ok=True)
+    os.makedirs(tst_dir, exist_ok=True)
+    n_files = 10
+    for i in range(n_files):
+        # "Convert" to sph becuase corpus expects that format and test doesn't read audio files
+        shutil.copy("tests/small-test-file.mp3", pjoin(trn_dir, "file-{:02d}.sph".format(i)))
+        shutil.copy("tests/small-test-file.stm", pjoin(trn_dir, "file-{:02d}.stm".format(i)))
+
+
+def validate_split(directory, inds):
+    """ Validate the files were split as expected """
+    assert set(os.listdir(directory)) == {
+        "file-{:02d}.{}".format(i, ext)
+        for ext in ['sph', 'stm']
+        for i in inds
+    }
+
+
+def test_split_corpus():
+    """ Test corpus splitter """
+    corpus_dir = "tests/split-corpus"
+
+    trn_dir = pjoin(corpus_dir, "train")
+    dev_dir = pjoin(corpus_dir, "dev")
+    tst_dir = pjoin(corpus_dir, "test")
+
+    setup_test_corpus(trn_dir, dev_dir, tst_dir)
+    split_corpus(trn_dir, dev_dir=dev_dir, dev_words=19, tst_dir=tst_dir, test_words=19, rand_seed=1337)
+    validate_split(trn_dir, [0, 1, 3, 4, 7, 9])
+    validate_split(dev_dir, [5, 6])
+    validate_split(tst_dir, [2, 8])
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+
+    pytest.main(sys.argv)

--- a/tests/test_split_corpus.py
+++ b/tests/test_split_corpus.py
@@ -7,18 +7,17 @@ import shutil
 from os.path import join as pjoin
 
 from asrtoolkit.split_corpus import split_corpus
+from asrtoolkit.data_structures.corpus import corpus
 
 
-def setup_test_corpus(trn_dir, dev_dir, tst_dir):
+def setup_test_corpus(orig_dir, trn_dir, dev_dir, n_exemplars):
     """ Setup fake corpus for testing """
+    os.makedirs(orig_dir, exist_ok=True)
     os.makedirs(trn_dir, exist_ok=True)
     os.makedirs(dev_dir, exist_ok=True)
-    os.makedirs(tst_dir, exist_ok=True)
-    n_files = 10
-    for i in range(n_files):
-        # "Convert" to sph becuase corpus expects that format and test doesn't read audio files
-        shutil.copy("tests/small-test-file.mp3", pjoin(trn_dir, "file-{:02d}.sph".format(i)))
-        shutil.copy("tests/small-test-file.stm", pjoin(trn_dir, "file-{:02d}.stm".format(i)))
+    for i in range(n_exemplars):
+        shutil.copy("tests/small-test-file.mp3", pjoin(orig_dir, "file-{:02d}.mp3".format(i)))
+        shutil.copy("tests/small-test-file.stm", pjoin(orig_dir, "file-{:02d}.stm".format(i)))
 
 
 def validate_split(directory, inds):
@@ -32,17 +31,37 @@ def validate_split(directory, inds):
 
 def test_split_corpus():
     """ Test corpus splitter """
+    n_exemplars = 10
     corpus_dir = "tests/split-corpus"
 
-    trn_dir = pjoin(corpus_dir, "train")
-    dev_dir = pjoin(corpus_dir, "dev")
-    tst_dir = pjoin(corpus_dir, "test")
+    orig_dir = pjoin(corpus_dir, "orig")
+    split_dir = pjoin(corpus_dir, "splits")
+    trn_dir = pjoin(split_dir, "train")
+    dev_dir = pjoin(split_dir, "dev")
 
-    setup_test_corpus(trn_dir, dev_dir, tst_dir)
-    split_corpus(trn_dir, dev_dir=dev_dir, dev_words=19, tst_dir=tst_dir, test_words=19, rand_seed=1337)
-    validate_split(trn_dir, [0, 1, 3, 4, 7, 9])
-    validate_split(dev_dir, [5, 6])
-    validate_split(tst_dir, [2, 8])
+    setup_test_corpus(orig_dir, trn_dir, dev_dir, n_exemplars)
+    orig_corpus = corpus({'location': orig_dir})
+    split_corpus(
+        orig_dir,
+        split_dir=split_dir,
+        split_name="dev",
+        split_words=19,
+        leftover_data_split_name="train",
+        rand_seed=1337,
+    )
+
+    # Make sure we didn't destroy input data
+    final_corpus = corpus({'location': orig_dir})
+    assert orig_corpus.validate() == 1
+    assert final_corpus.validate() == 1
+    orig_hashes = [_.hash() for _ in orig_corpus.exemplars]
+    final_hashes = [_.hash() for _ in final_corpus.exemplars]
+    assert all(h in final_hashes for h in orig_hashes)
+
+    # Make sure correct number of words present in data split
+    dev_corpus = corpus({'location': dev_dir})
+    assert dev_corpus.validate()
+    assert sum(e.count_words() for e in dev_corpus.exemplars) == 20
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds script `split_corpus.py` which creates data splits for a corpus with close to a defined number of words. This is useful to ensure WER calculations for dev and tests data are accurate while also preserving as much data for training as possible.

A script to test asrtoolkit using the docker image was also added.