### PR TITLE
preserve noise tags which are bracketed

### DIFF
--- a/asrtoolkit/clean_formatting.py
+++ b/asrtoolkit/clean_formatting.py
@@ -187,6 +187,8 @@ def clean_up(input_line):
     'i heard mr mcdonald has six dollars and twenty three cents'
     >>> clean_up(" for client X (hide name pls), plz giv $1 mln shs thx")
     'for client x hide name please please giv one million dollars shs thanks'
+    >>> clean_up("[laughter]")
+    '[laughter]'
     """
 
     if check_for_formatted_chars(input_line):

--- a/asrtoolkit/clean_formatting.py
+++ b/asrtoolkit/clean_formatting.py
@@ -23,7 +23,7 @@ from asrtoolkit.file_utils.script_input_validation import valid_input_file
 LOGGER = logging.getLogger(__name__)
 
 # preserve any unicode letters
-invalid_chars = re.compile(r"[^\p{L}<> \']", re.IGNORECASE)
+invalid_chars = re.compile(r"[^\p{L}<\[\]> \']", re.IGNORECASE)
 
 spaces = re.compile(r"\s+")
 

--- a/asrtoolkit/data_handlers/stm.py
+++ b/asrtoolkit/data_handlers/stm.py
@@ -21,11 +21,11 @@ def format_segment(seg):
       Formats a segment assuming it's an instance of class segment with elements
       filename, channel, speaker, start and stop times, label, and text
     """
+    # clean_up used to unformat stm file text
     return " ".join([
         str(getattr(seg, _))
         for _ in ("filename", "channel", "speaker", "start", "stop", "label")
-    ] + [clean_up(seg.text)]  # clean_up used to unformat stm file text
-                    )
+    ] + [clean_up(seg.text)])
 
 
 def parse_line(line):

--- a/asrtoolkit/prepare_audio_corpora.py
+++ b/asrtoolkit/prepare_audio_corpora.py
@@ -106,7 +106,7 @@ def prepare_audio_corpora(*corpora, target_dir="input-data", nested=False):
     Training, testing, and development sets will be created automatically if not already defined.
 
     Input
-        corpora, strs - name of one or more directories to combine into `target-dir` 
+        corpora, strs - name of one or more directories to combine into `target-dir`
         target-dir, str - target directory where corpora should be organized
         nested, bool (default False)- if present/True, store in stm and sph subdirectories
     """


### PR DESCRIPTION
`clean_up` previously assumed that all noise tags would be angle-bracketed, but many are actually normally bracketed. 

compare `<unk>` against `[laughter]`