### PR TITLE
make sure was can handle mixed label and test that functionality

### DIFF
--- a/asrtoolkit/data_structures/segment.py
+++ b/asrtoolkit/data_structures/segment.py
@@ -81,7 +81,7 @@ class segment(object):
         """
         valid = (self.speaker != "inter_segment_gap" and self.text
                  and self.text != "ignore_time_segment_in_scoring"
-                 and self.label in ["<o,f0,male>", "<o,f0,female>"])
+                 and self.label in ["<o,f0,male>", "<o,f0,female>", "<o,f0,mixed>"])
 
         try:
             self.start = clean_float(self.start)

--- a/tests/small-test-file.stm
+++ b/tests/small-test-file.stm
@@ -1,2 +1,2 @@
-small-test-file 1 gk_speaker 0.765 2.881 <o,f0,male> one two three four five
-small-test-file 1 gk_speaker 5.008 6.966 <o,f0,male> six seven eight nine ten
+small-test-file 1 gk_speaker 0.765 2.881 <o,f0,mixed> one two three four five
+small-test-file 1 gk_speaker 5.008 6.966 <o,f0,female> six seven eight nine ten


### PR DESCRIPTION
Some stm files have a mixed label we should allow for. Adds test that exercizes possible labels and I confirmed locally that using an invalid lable causes tests to fail.