### PR TITLE
Give n_words a default so there is no error if it's accessed before it's defined

### DIFF
--- a/asrtoolkit/data_structures/corpus.py
+++ b/asrtoolkit/data_structures/corpus.py
@@ -113,6 +113,7 @@ class corpus(object):
 
     location = None
     exemplars = []
+    n_words = 0
 
     def __init__(self, *args, **kwargs):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ regex
 termcolor
 tqdm
 webvtt-py
-xlrd
+xlrd<=1.2.0


### PR DESCRIPTION
The lack of default caused an error when iterating over all exemplars. This was an oversight when I added this attribute!