### PR TITLE
add support for rttm output as a common format for diarization

### DIFF
--- a/asrtoolkit/data_handlers/json.py
+++ b/asrtoolkit/data_handlers/json.py
@@ -70,11 +70,13 @@ def parse_segment(input_seg):
 
         """
         dict_key = value if dict_key is None else dict_key
-
+        ret_val = None
         if value in input_seg and interior_key and interior_key in input_seg[value]:
-            extracted_dict[dict_key] = proc_val(input_seg[value][interior_key])
+            ret_val = proc_val(input_seg[value][interior_key])
         elif value in input_seg and not interior_key:
-            extracted_dict[dict_key] = proc_val(input_seg[value])
+            ret_val = proc_val(input_seg[value])
+        if ret_val not in {"", None}:
+            extracted_dict[dict_key] = ret_val
 
     seg = None
     try:
@@ -86,7 +88,7 @@ def parse_segment(input_seg):
         assign_if_present("corrected_transcript", "text")
         assign_if_present("formatted_transcript", "formatted_text")
         assign_if_present("punctuated_transcript", "formatted_text")
-        assign_if_present("speakerInfo", "speaker", "ID", proc_val=sanitize)
+        assign_if_present("speakerInfo", "speaker", proc_val=sanitize)
         assign_if_present(
             "genderInfo", "label", "gender", lambda gender: "<o,f0,{:}>".format(gender)
         )

--- a/asrtoolkit/data_handlers/json.py
+++ b/asrtoolkit/data_handlers/json.py
@@ -86,7 +86,7 @@ def parse_segment(input_seg):
         assign_if_present("corrected_transcript", "text")
         assign_if_present("formatted_transcript", "formatted_text")
         assign_if_present("punctuated_transcript", "formatted_text")
-        assign_if_present("speakerInfo", "speaker", proc_val=sanitize)
+        assign_if_present("speakerInfo", "speaker", "ID", proc_val=sanitize)
         assign_if_present(
             "genderInfo", "label", "gender", lambda gender: "<o,f0,{:}>".format(gender)
         )

--- a/asrtoolkit/data_handlers/json.py
+++ b/asrtoolkit/data_handlers/json.py
@@ -7,6 +7,7 @@ import json
 import logging
 
 from asrtoolkit.data_structures.segment import segment
+from asrtoolkit.file_utils.name_cleaners import sanitize
 
 LOGGER = logging.getLogger(__name__)
 separator = ",\n"
@@ -85,7 +86,7 @@ def parse_segment(input_seg):
         assign_if_present("corrected_transcript", "text")
         assign_if_present("formatted_transcript", "formatted_text")
         assign_if_present("punctuated_transcript", "formatted_text")
-        assign_if_present("speakerInfo", "speaker", "ID")
+        assign_if_present("speakerInfo", "speaker", proc_val=sanitize)
         assign_if_present(
             "genderInfo", "label", "gender", lambda gender: "<o,f0,{:}>".format(gender)
         )

--- a/asrtoolkit/data_handlers/rttm.py
+++ b/asrtoolkit/data_handlers/rttm.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""
+Module for reading/writing RTTM files
+
+This expects a segment from class derived in convert_text
+
+See https://catalog.ldc.upenn.edu/docs/LDC2004T12/RTTM-format-v13.pdf
+for the RTTM file format standard, copied below with minor edits for clarity
+
+RTTM files store object attributes in white-space separated fields
+
+```
+Field 1 2 3 4 5 6 7 8 9
+type file chnl tbeg tdur ortho stype name conf
+```
+where
+file is the waveform file base name (i.e., without path names or extensions).
+chnl is the waveform channel (e.g., “1” or “2”).
+tbeg is the beginning time of the object, in seconds, measured from the start time of the file. If there is no beginning time, use tbeg = “<NA>”.
+tdur is the duration of the object, in seconds. If there is no duration, use tdur = “<NA>”.
+stype is the subtype of the object. If there is no subtype, use stype = “<NA>”.
+ortho is the orthographic rendering (spelling) of the object for STT object types. If there is no orthographic representation, use ortho = “<NA>”.
+name is the name of the speaker. name must uniquely specify the speaker within the scope of the file. If name is not applicable or if no claim is being made as to the identity of the speaker, use name = “<NA>”.
+conf is the confidence (probability) that the object information is correct. If conf is not available, use conf = “<NA>”.    
+
+"""
+
+# do not delete - needed for time_aligned_text
+from asrtoolkit.data_handlers.data_handlers_common import footer, separator
+from asrtoolkit.data_structures.segment import segment
+from asrtoolkit.data_structures.formatting import clean_float
+
+def header():
+    "Header for rttm files is empty"
+    return ""
+
+
+def format_segment(seg):
+    """
+    Formats a segment assuming it's an instance of class segment with elements
+    filename, channel, speaker, start and stop times, label, and text
+    """
+    return f"SPEAKER {seg.filename} {seg.channel} {seg.start} {clean_float(float(seg.stop)-float(seg.start))} <NA> <NA> {seg.speaker} <NA> <NA>"
+
+
+def read_file(file_name):
+    """ Reads an RTTM file """
+
+    segments = []
+    with open(file_name) as data:
+        for line in data:
+            _, filename, channel, start, duration, _, _, speaker, _, _ = line.split()
+            seg = segment(
+                **dict(
+                    filename=filename,
+                    channel=channel,
+                    start=start,
+                    stop=start + duration,
+                    speaker=speaker,
+                )
+            )
+            segments.append(seg)
+    return segments
+
+
+__all__ = [header, footer, separator]

--- a/asrtoolkit/file_utils/script_input_validation.py
+++ b/asrtoolkit/file_utils/script_input_validation.py
@@ -13,11 +13,13 @@ VALID_EXTENSIONS = ["json", "srt", "stm", "vtt", "txt", "html"]
 def valid_input_file(file_name, valid_extensions=[]):
     """
     tests that a file exists and that the extension is one asrtoolkit scripts can accept
-    >>> valid_input_file("setup.py")
+    >>> import os
+    >>> module_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+    >>> valid_input_file(f"{module_path}/setup.py")
     False
-    >>> valid_input_file("setup.py", ["py"])
+    >>> valid_input_file(f"{module_path}/setup.py", ["py"])
     True
-    >>> valid_input_file("requirements.txt")
+    >>> valid_input_file(f"{module_path}/requirements.txt", ["txt"])
     True
     """
     return isfile(file_name) and get_extension(file_name) in (

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ pkgs, new_links = install_deps()
 
 setup(
     name="asrtoolkit",
-    version="0.2.4",
+    version="0.2.5-alpha1",
     description="The GreenKey ASRToolkit provides tools for automatic speech recognition (ASR) file conversion and corpora organization.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/no_speaker.json
+++ b/tests/no_speaker.json
@@ -1,0 +1,18 @@
+{
+  "segments": [
+    {
+      "final": true,
+      "words": [
+        { "word": "yeah", "start": 0.54, "length": 0.18, "confidence": 0.53 },
+        { "word": "i", "start": 1.44, "length": 0.27, "confidence": 0.62 },
+        { "word": "uh", "start": 1.71, "length": 0.12, "confidence": 0.44 }
+      ],
+      "transcript": "yeah i uh",
+      "startTimeSec": 0.0,
+      "endTimeSec": 2.0,
+      "speakerInfo": "",
+      "confidence": 1.0
+    }
+  ]
+}
+

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env sh
-
-python3 -m pytest -vv --doctest-modules
+#!/usr/bin/env bash
+test_dir="$(dirname "${BASH_SOURCE[0]}")"
+python3 -m pytest -vv --doctest-modules $test_dir/../

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -2,22 +2,23 @@
 """
 Test to ensure that alignment can work
 """
-import hashlib
 
-from asrtoolkit import align_json
+from asrtoolkit import align_json, time_aligned_text
+from utils import get_sample_dir, get_test_dir
+
+test_dir = get_test_dir(__file__)
+sample_dir = get_sample_dir(__file__)
 
 
 def test_simple_alignment():
     align_json(
-        "samples/BillGatesTEDTalk.txt",
-        "samples/BillGatesTEDTalk.json",
-        "tests/BillGatesTEDTalk_aligned.stm",
+        f"{sample_dir}/BillGatesTEDTalk.txt",
+        f"{sample_dir}/BillGatesTEDTalk.json",
+        f"{test_dir}/BillGatesTEDTalk_aligned.stm",
     )
-    new_sha = hashlib.sha1(
-        open("tests/BillGatesTEDTalk_aligned.stm", "r", encoding="utf8").read().encode()
-    ).hexdigest()
-    reference_sha = "0d4a20cf54fdc2834c69d9697c5820556139379e"
-    assert new_sha == reference_sha
+
+    aligned_transcript = time_aligned_text(f"{test_dir}/BillGatesTEDTalk_aligned.stm")
+    assert len(aligned_transcript.segments) == 104
 
 
 if __name__ == "__main__":

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -17,7 +17,7 @@ def test_simple_alignment():
         open("tests/BillGatesTEDTalk_aligned.stm", "r", encoding="utf8").read().encode()
     ).hexdigest()
     reference_sha = "0d4a20cf54fdc2834c69d9697c5820556139379e"
-    assert reference_sha == new_sha
+    assert new_sha == reference_sha
 
 
 if __name__ == "__main__":

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -2,7 +2,7 @@
 """
 Test file conversion using samples
 """
-
+import os
 import hashlib
 
 from asrtoolkit.data_structures.time_aligned_text import time_aligned_text
@@ -15,110 +15,76 @@ sample_dir = get_sample_dir(__file__)
 def test_stm_to_txt_conversion():
     " execute stm to txt test "
 
-    input_file = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.stm")
-    input_file.write(f"{test_dir}/stm_to_txt_test.txt")
-    reference_sha = hashlib.sha1(
-        open(f"{sample_dir}/BillGatesTEDTalk.txt", "r", encoding="utf8").read().encode()
-    ).hexdigest()
-    new_sha = hashlib.sha1(
-        open(f"{test_dir}/stm_to_txt_test.txt", "r", encoding="utf8").read().encode()
-    ).hexdigest()
-    assert reference_sha == new_sha
+    transcript = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.stm")
+    convert_and_test_it_loads(transcript, f"{test_dir}/stm_to_txt_test.txt")
 
 
 def test_stm_to_html_conversion():
     " execute stm to html test "
 
-    input_file = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.stm")
-    input_file.write(f"{test_dir}/stm_to_html_test.html")
-    reference_sha = hashlib.sha1(
-        open(f"{sample_dir}/BillGatesTEDTalk.html", "r", encoding="utf8")
-        .read()
-        .encode()
-    ).hexdigest()
-    new_sha = hashlib.sha1(
-        open(f"{test_dir}/stm_to_html_test.html", "r", encoding="utf8").read().encode()
-    ).hexdigest()
-    assert reference_sha == new_sha
+    transcript = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.stm")
+    convert_and_test_it_loads(transcript, f"{test_dir}/stm_to_html_test.html")
 
 
 def test_stm_to_vtt_conversion():
     " execute stm to vtt test "
 
-    input_file = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.stm")
-    input_file.write(f"{test_dir}/stm_to_vtt_test.vtt")
-
-    reference_sha = hashlib.sha1(
-        open(f"{sample_dir}/BillGatesTEDTalk.vtt", "r", encoding="utf8").read().encode()
-    ).hexdigest()
-    new_sha = hashlib.sha1(
-        open(f"{test_dir}/stm_to_vtt_test.vtt", "r", encoding="utf8").read().encode()
-    ).hexdigest()
-    assert reference_sha == new_sha
+    transcript = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.stm")
+    convert_and_test_it_loads(transcript, f"{test_dir}/stm_to_vtt_test.vtt")
 
 
 def test_stm_to_srt_conversion():
     " execute stm to srt test "
 
-    input_file = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.stm")
-    input_file.write(f"{test_dir}/stm_to_srt_test.srt")
-
-    reference_sha = hashlib.sha1(
-        open(f"{sample_dir}/BillGatesTEDTalk.srt", "r", encoding="utf8").read().encode()
-    ).hexdigest()
-    new_sha = hashlib.sha1(
-        open(f"{test_dir}/stm_to_srt_test.srt", "r", encoding="utf8").read().encode()
-    ).hexdigest()
-    assert reference_sha == new_sha
+    transcript = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.stm")
+    convert_and_test_it_loads(transcript, f"{test_dir}/stm_to_srt_test.srt")
 
 
 def test_json_to_stm_conversion():
     " execute json to stm tests "
 
-    input_file = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.json")
-    reference_sha = hashlib.sha1(
-        open(f"{sample_dir}/BillGatesTEDTalk_transcribed.stm", "r", encoding="utf8")
-        .read()
-        .encode()
-    ).hexdigest()
-    input_file.write(f"{test_dir}/json_to_stm_test_1.stm")
-    new_sha = hashlib.sha1(
-        open(f"{test_dir}/json_to_stm_test_1.stm", "r", encoding="utf8").read().encode()
-    ).hexdigest()
-    assert reference_sha == new_sha
+    transcript = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.json")
+    convert_and_test_it_loads(transcript, f"{test_dir}/json_to_stm_test_1.stm")
 
-    input_file = time_aligned_text(f"{sample_dir}/simple_test.json")
-    reference_sha = hashlib.sha1(
-        open(f"{sample_dir}/simple_test.stm", "r", encoding="utf8").read().encode()
-    ).hexdigest()
-    input_file.write(f"{test_dir}/json_to_stm_test_2.stm")
-    new_sha = hashlib.sha1(
-        open(f"{test_dir}/json_to_stm_test_2.stm", "r", encoding="utf8").read().encode()
-    ).hexdigest()
-    assert reference_sha == new_sha
+    transcript = time_aligned_text(f"{sample_dir}/simple_test.json")
+    convert_and_test_it_loads(transcript, f"{test_dir}/json_to_stm_test_2.stm")
 
 
 def test_json_to_txt_conversion():
     " execute json to txt test "
 
-    input_file = time_aligned_text(f"{sample_dir}/simple_test.json")
-    reference_sha = hashlib.sha1(
-        open(f"{sample_dir}/simple_test.txt", "r", encoding="utf8").read().encode()
-    ).hexdigest()
-    input_file.write(f"{test_dir}/json_to_txt_test.txt")
-    new_sha = hashlib.sha1(
-        open(f"{test_dir}/json_to_txt_test.txt", "r", encoding="utf8").read().encode()
-    ).hexdigest()
-    assert reference_sha == new_sha
+    transcript = time_aligned_text(f"{sample_dir}/simple_test.json")
+    convert_and_test_it_loads(transcript, f"{test_dir}/json_to_txt_test.txt")
+
 
 def test_json_to_rttm_conversion():
     """
     execute json to rttm test
     """
-    input_file = time_aligned_text(f"{sample_dir}/simple_test.json")
-    input_file.write(f"{test_dir}/json_to_rttm_test.rttm")
-    # ensure it can load again
-    time_aligned_text(f"{test_dir}/json_to_rttm_test.rttm")
+    transcript = time_aligned_text(f"{sample_dir}/simple_test.json")
+    convert_and_test_it_loads(transcript, f"{test_dir}/json_to_rttm_test.rttm")
+
+
+def test_json_to_rttm_conversion_without_speaker():
+    """
+    execute json to rttm test
+    """
+    transcript = time_aligned_text(f"{test_dir}/no_speaker.json")
+
+    convert_and_test_it_loads(transcript, f"{test_dir}/no_speaker.rttm")
+
+
+def convert_and_test_it_loads(transcript_obj, output_filename):
+    """
+    Tests that conversion works
+    Tests that the file can reload
+    Removes transitory file
+    """
+    transcript_obj.write(output_filename)
+    time_aligned_text(output_filename)
+
+    os.remove(output_filename)
+
 
 if __name__ == "__main__":
     import sys

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -6,18 +6,22 @@ Test file conversion using samples
 import hashlib
 
 from asrtoolkit.data_structures.time_aligned_text import time_aligned_text
+from utils import get_sample_dir, get_test_dir
+
+test_dir = get_test_dir(__file__)
+sample_dir = get_sample_dir(__file__)
 
 
 def test_stm_to_txt_conversion():
     " execute stm to txt test "
 
-    input_file = time_aligned_text("samples/BillGatesTEDTalk.stm")
-    input_file.write("tests/stm_to_txt_test.txt")
+    input_file = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.stm")
+    input_file.write(f"{test_dir}/stm_to_txt_test.txt")
     reference_sha = hashlib.sha1(
-        open("samples/BillGatesTEDTalk.txt", "r", encoding="utf8").read().encode()
+        open(f"{sample_dir}/BillGatesTEDTalk.txt", "r", encoding="utf8").read().encode()
     ).hexdigest()
     new_sha = hashlib.sha1(
-        open("tests/stm_to_txt_test.txt", "r", encoding="utf8").read().encode()
+        open(f"{test_dir}/stm_to_txt_test.txt", "r", encoding="utf8").read().encode()
     ).hexdigest()
     assert reference_sha == new_sha
 
@@ -25,13 +29,15 @@ def test_stm_to_txt_conversion():
 def test_stm_to_html_conversion():
     " execute stm to html test "
 
-    input_file = time_aligned_text("samples/BillGatesTEDTalk.stm")
-    input_file.write("tests/stm_to_html_test.html")
+    input_file = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.stm")
+    input_file.write(f"{test_dir}/stm_to_html_test.html")
     reference_sha = hashlib.sha1(
-        open("samples/BillGatesTEDTalk.html", "r", encoding="utf8").read().encode()
+        open(f"{sample_dir}/BillGatesTEDTalk.html", "r", encoding="utf8")
+        .read()
+        .encode()
     ).hexdigest()
     new_sha = hashlib.sha1(
-        open("tests/stm_to_html_test.html", "r", encoding="utf8").read().encode()
+        open(f"{test_dir}/stm_to_html_test.html", "r", encoding="utf8").read().encode()
     ).hexdigest()
     assert reference_sha == new_sha
 
@@ -39,14 +45,14 @@ def test_stm_to_html_conversion():
 def test_stm_to_vtt_conversion():
     " execute stm to vtt test "
 
-    input_file = time_aligned_text("samples/BillGatesTEDTalk.stm")
-    input_file.write("tests/stm_to_vtt_test.vtt")
+    input_file = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.stm")
+    input_file.write(f"{test_dir}/stm_to_vtt_test.vtt")
 
     reference_sha = hashlib.sha1(
-        open("samples/BillGatesTEDTalk.vtt", "r", encoding="utf8").read().encode()
+        open(f"{sample_dir}/BillGatesTEDTalk.vtt", "r", encoding="utf8").read().encode()
     ).hexdigest()
     new_sha = hashlib.sha1(
-        open("tests/stm_to_vtt_test.vtt", "r", encoding="utf8").read().encode()
+        open(f"{test_dir}/stm_to_vtt_test.vtt", "r", encoding="utf8").read().encode()
     ).hexdigest()
     assert reference_sha == new_sha
 
@@ -54,14 +60,14 @@ def test_stm_to_vtt_conversion():
 def test_stm_to_srt_conversion():
     " execute stm to srt test "
 
-    input_file = time_aligned_text("samples/BillGatesTEDTalk.stm")
-    input_file.write("tests/stm_to_srt_test.srt")
+    input_file = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.stm")
+    input_file.write(f"{test_dir}/stm_to_srt_test.srt")
 
     reference_sha = hashlib.sha1(
-        open("samples/BillGatesTEDTalk.srt", "r", encoding="utf8").read().encode()
+        open(f"{sample_dir}/BillGatesTEDTalk.srt", "r", encoding="utf8").read().encode()
     ).hexdigest()
     new_sha = hashlib.sha1(
-        open("tests/stm_to_srt_test.srt", "r", encoding="utf8").read().encode()
+        open(f"{test_dir}/stm_to_srt_test.srt", "r", encoding="utf8").read().encode()
     ).hexdigest()
     assert reference_sha == new_sha
 
@@ -69,25 +75,25 @@ def test_stm_to_srt_conversion():
 def test_json_to_stm_conversion():
     " execute json to stm tests "
 
-    input_file = time_aligned_text("samples/BillGatesTEDTalk.json")
+    input_file = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.json")
     reference_sha = hashlib.sha1(
-        open("samples/BillGatesTEDTalk_transcribed.stm", "r", encoding="utf8")
+        open(f"{sample_dir}/BillGatesTEDTalk_transcribed.stm", "r", encoding="utf8")
         .read()
         .encode()
     ).hexdigest()
-    input_file.write("tests/json_to_stm_test_1.stm")
+    input_file.write(f"{test_dir}/json_to_stm_test_1.stm")
     new_sha = hashlib.sha1(
-        open("tests/json_to_stm_test_1.stm", "r", encoding="utf8").read().encode()
+        open(f"{test_dir}/json_to_stm_test_1.stm", "r", encoding="utf8").read().encode()
     ).hexdigest()
     assert reference_sha == new_sha
 
-    input_file = time_aligned_text("samples/simple_test.json")
+    input_file = time_aligned_text(f"{sample_dir}/simple_test.json")
     reference_sha = hashlib.sha1(
-        open("samples/simple_test.stm", "r", encoding="utf8").read().encode()
+        open(f"{sample_dir}/simple_test.stm", "r", encoding="utf8").read().encode()
     ).hexdigest()
-    input_file.write("tests/json_to_stm_test_2.stm")
+    input_file.write(f"{test_dir}/json_to_stm_test_2.stm")
     new_sha = hashlib.sha1(
-        open("tests/json_to_stm_test_2.stm", "r", encoding="utf8").read().encode()
+        open(f"{test_dir}/json_to_stm_test_2.stm", "r", encoding="utf8").read().encode()
     ).hexdigest()
     assert reference_sha == new_sha
 
@@ -95,13 +101,13 @@ def test_json_to_stm_conversion():
 def test_json_to_txt_conversion():
     " execute json to txt test "
 
-    input_file = time_aligned_text("samples/simple_test.json")
+    input_file = time_aligned_text(f"{sample_dir}/simple_test.json")
     reference_sha = hashlib.sha1(
-        open("samples/simple_test.txt", "r", encoding="utf8").read().encode()
+        open(f"{sample_dir}/simple_test.txt", "r", encoding="utf8").read().encode()
     ).hexdigest()
-    input_file.write("tests/json_to_txt_test.txt")
+    input_file.write(f"{test_dir}/json_to_txt_test.txt")
     new_sha = hashlib.sha1(
-        open("tests/json_to_txt_test.txt", "r", encoding="utf8").read().encode()
+        open(f"{test_dir}/json_to_txt_test.txt", "r", encoding="utf8").read().encode()
     ).hexdigest()
     assert reference_sha == new_sha
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -111,6 +111,14 @@ def test_json_to_txt_conversion():
     ).hexdigest()
     assert reference_sha == new_sha
 
+def test_json_to_rttm_conversion():
+    """
+    execute json to rttm test
+    """
+    input_file = time_aligned_text(f"{sample_dir}/simple_test.json")
+    input_file.write(f"{test_dir}/json_to_rttm_test.rttm")
+    # ensure it can load again
+    time_aligned_text(f"{test_dir}/json_to_rttm_test.rttm")
 
 if __name__ == "__main__":
     import sys

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -8,21 +8,28 @@ import json
 
 from asrtoolkit.data_structures.time_aligned_text import time_aligned_text
 
+from utils import get_sample_dir, get_test_dir
+
+test_dir = get_test_dir(__file__)
+sample_dir = get_sample_dir(__file__)
+
 
 def test_json_initialization():
     " execute single test "
 
-    input_dict = json.load(open("samples/BillGatesTEDTalk.json"))
+    input_dict = json.load(open(f"{sample_dir}/BillGatesTEDTalk.json"))
     text_object = time_aligned_text(input_dict)
 
     reference_sha = hashlib.sha1(
-        open("samples/BillGatesTEDTalk_transcribed.stm", "r", encoding="utf8")
+        open(f"{sample_dir}/BillGatesTEDTalk_transcribed.stm", "r", encoding="utf8")
         .read()
         .encode()
     ).hexdigest()
-    text_object.write("tests/file_conversion_test.stm")
+    text_object.write(f"{test_dir}/file_conversion_test.stm")
     new_sha = hashlib.sha1(
-        open("tests/file_conversion_test.stm", "r", encoding="utf8").read().encode()
+        open(f"{test_dir}/file_conversion_test.stm", "r", encoding="utf8")
+        .read()
+        .encode()
     ).hexdigest()
     assert reference_sha == new_sha
 
@@ -30,20 +37,22 @@ def test_json_initialization():
 def test_txt_initialization():
     " execute single test "
 
-    input_dict = json.load(open("samples/BillGatesTEDTalk.json"))
+    input_dict = json.load(open(f"{sample_dir}/BillGatesTEDTalk.json"))
     text = time_aligned_text(input_dict)
     text.file_extension = "txt"
 
     text_object = time_aligned_text(text.__str__())
 
     reference_sha = hashlib.sha1(
-        open("samples/BillGatesTEDTalk_transcribed.txt", "r", encoding="utf8")
+        open(f"{sample_dir}/BillGatesTEDTalk_transcribed.txt", "r", encoding="utf8")
         .read()
         .encode()
     ).hexdigest()
-    text_object.write("tests/file_conversion_test.txt")
+    text_object.write(f"{test_dir}/file_conversion_test.txt")
     new_sha = hashlib.sha1(
-        open("tests/file_conversion_test.txt", "r", encoding="utf8").read().encode()
+        open(f"{test_dir}/file_conversion_test.txt", "r", encoding="utf8")
+        .read()
+        .encode()
     ).hexdigest()
     assert reference_sha == new_sha
 

--- a/tests/test_remove_invalid_lines.py
+++ b/tests/test_remove_invalid_lines.py
@@ -5,6 +5,11 @@ Test invalid line removal
 
 from asrtoolkit.convert_transcript import convert
 from asrtoolkit.data_structures.time_aligned_text import time_aligned_text
+from utils import get_sample_dir, get_test_dir
+
+test_dir = get_test_dir(__file__)
+sample_dir = get_sample_dir(__file__)
+
 
 EXPECTED_UNFORMATTED_TRANSCRIPTS = (
     "testing testing one two three or maybe ten four",
@@ -20,8 +25,8 @@ EXPECTED_FORMATTED_TRANSCRIPTS = (
 
 
 def validate_sample(ext, expected_transcripts, out_segments):
-    base_output = "tests/good"
-    convert("samples/invalid.stm", base_output + ext)
+    base_output = f"{test_dir}/good"
+    convert(f"{sample_dir}/invalid.stm", base_output + ext)
     validated_transcript = time_aligned_text(base_output + ext)
     assert len(validated_transcript.segments) == out_segments
     for seg, expected_text in zip(validated_transcript.segments, expected_transcripts):

--- a/tests/test_split_audio_file.py
+++ b/tests/test_split_audio_file.py
@@ -5,6 +5,9 @@ Test audio file splitter
 import os
 
 from asrtoolkit.split_audio_file import split_audio_file
+from utils import get_test_dir
+
+test_dir = get_test_dir(__file__)
 
 
 def test_split_audio_file():
@@ -12,9 +15,11 @@ def test_split_audio_file():
     Test audio file splitter
     """
     split_audio_file(
-        "tests/small-test-file.mp3", "tests/small-test-file.stm", "tests/split"
+        f"{test_dir}/small-test-file.mp3",
+        f"{test_dir}/small-test-file.stm",
+        f"{test_dir}/split",
     )
-    assert set(os.listdir("tests/split")) == {
+    assert set(os.listdir(f"{test_dir}/split")) == {
         "small_test_file_seg_00001.stm",
         "small_test_file_seg_00000.mp3",
         "small_test_file_seg_00001.mp3",

--- a/tests/test_split_corpus.py
+++ b/tests/test_split_corpus.py
@@ -8,6 +8,10 @@ from os.path import join as pjoin
 
 from asrtoolkit.data_structures.corpus import corpus
 from asrtoolkit.split_corpus import split_corpus
+from utils import get_sample_dir, get_test_dir
+
+test_dir = get_test_dir(__file__)
+sample_dir = get_sample_dir(__file__)
 
 
 def setup_test_corpus(orig_dir, trn_dir, dev_dir, n_exemplars):
@@ -17,10 +21,12 @@ def setup_test_corpus(orig_dir, trn_dir, dev_dir, n_exemplars):
     os.makedirs(dev_dir, exist_ok=True)
     for i in range(n_exemplars):
         shutil.copy(
-            "tests/small-test-file.mp3", pjoin(orig_dir, "file-{:02d}.mp3".format(i))
+            f"{test_dir}/small-test-file.mp3",
+            pjoin(orig_dir, "file-{:02d}.mp3".format(i)),
         )
         shutil.copy(
-            "tests/small-test-file.stm", pjoin(orig_dir, "file-{:02d}.stm".format(i))
+            f"{test_dir}/small-test-file.stm",
+            pjoin(orig_dir, "file-{:02d}.stm".format(i)),
         )
 
 
@@ -34,7 +40,7 @@ def validate_split(directory, inds):
 def test_split_corpus():
     """ Test corpus splitter """
     n_exemplars = 10
-    corpus_dir = "tests/split-corpus"
+    corpus_dir = f"{test_dir}/split-corpus"
 
     orig_dir = pjoin(corpus_dir, "orig")
     split_dir = pjoin(corpus_dir, "splits")

--- a/tests/test_wer.py
+++ b/tests/test_wer.py
@@ -5,14 +5,17 @@ Test wer calculation
 
 from asrtoolkit.data_structures.time_aligned_text import time_aligned_text
 from asrtoolkit.wer import cer, wer
+from utils import get_sample_dir
+
+sample_dir = get_sample_dir(__file__)
 
 
 def test_conversion_wer():
     " execute single test "
 
-    reference_file = time_aligned_text("samples/BillGatesTEDTalk.stm")
+    reference_file = time_aligned_text(f"{sample_dir}/BillGatesTEDTalk.stm")
     transcript_file = time_aligned_text(
-        "samples/BillGatesTEDTalk_intentionally_poor_transcription.txt"
+        f"{sample_dir}/BillGatesTEDTalk_intentionally_poor_transcription.txt"
     )
 
     # test fixed precision output of wer calculation

--- a/tests/test_xlsx_extraction.py
+++ b/tests/test_xlsx_extraction.py
@@ -7,12 +7,16 @@ import os
 
 from asrtoolkit.extract_excel_spreadsheets import proc_input_dir_to_corpus
 
+from utils import get_test_dir
+
+test_dir = get_test_dir(__file__)
+
 
 def test_excel_conversion():
     " execute single test "
 
-    proc_input_dir_to_corpus("samples", "tests/corpus")
-    assert os.path.exists("tests/corpus/FinancialStatementFY18Q4.txt")
+    proc_input_dir_to_corpus("samples", f"{test_dir}/corpus")
+    assert os.path.exists(f"{test_dir}/corpus/FinancialStatementFY18Q4.txt")
 
 
 if __name__ == "__main__":

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""
+Helper functions to find the test and sample directories
+"""
+import os
+
+
+def get_test_dir(input_file):
+    """
+    >>> get_test_dir(__file__).endswith("tests")
+    True
+    """
+    return os.path.dirname(os.path.realpath(input_file))
+
+
+def get_sample_dir(input_file):
+    """
+    >>> get_sample_dir(__file__).endswith("samples")
+    True
+    """
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(input_file))), "samples"
+    )


### PR DESCRIPTION
This makes it easier internally to use convert_transcript to export from asr output into rttm formats so we can evaluate our diarization accuracy

- fixes tests so they can be run from anywhere
- fixes speaker id loading
- adds rttm file format
- update test for alignment