### PR TITLE
Enforce a line break as the stm footer

### DIFF
--- a/asrtoolkit/data_handlers/stm.py
+++ b/asrtoolkit/data_handlers/stm.py
@@ -13,6 +13,7 @@ from asrtoolkit.clean_formatting import clean_up
 from asrtoolkit.data_handlers.data_handlers_common import footer, header, separator
 from asrtoolkit.data_structures.segment import segment
 
+footer = "\n"
 
 def format_segment(seg):
     """

--- a/asrtoolkit/data_handlers/stm.py
+++ b/asrtoolkit/data_handlers/stm.py
@@ -13,7 +13,11 @@ from asrtoolkit.clean_formatting import clean_up
 from asrtoolkit.data_handlers.data_handlers_common import footer, header, separator
 from asrtoolkit.data_structures.segment import segment
 
-footer = "\n"
+
+def footer():
+    " Returns footer with trailing line break "
+    return "\n"
+
 
 def format_segment(seg):
     """


### PR DESCRIPTION
The lack of a training line break for the STM file can be problematic for single line files as kaldi will simply aggregate them together.